### PR TITLE
Set default value for main args parameter

### DIFF
--- a/worlds/keymasters_keep/client.py
+++ b/worlds/keymasters_keep/client.py
@@ -498,7 +498,7 @@ class KeymastersKeepContext(CommonClient.CommonContext):
                 self.game_state["shop_items_purchased"][shop] = purchased_items
 
 
-def main(args: typing.Sequence[str] | None) -> None:
+def main(args: typing.Sequence[str] | None = None) -> None:
     Utils.init_logging("KeymastersKeepClient", exception_logger="Client")
     parser = CommonClient.get_base_parser()
     args, uri = parser.parse_known_args(args)


### PR DESCRIPTION
The main function in client.py now defaults the 'args' parameter to None, improving compatibility with callers that do not provide arguments.