### PR TITLE
Force incompatible SAWS settings

### DIFF
--- a/worlds/factorio_saws/data/mod/settings-final-fixes.lua
+++ b/worlds/factorio_saws/data/mod/settings-final-fixes.lua
@@ -1,0 +1,10 @@
+-- Force SAWS settings because the mod generation assume a specific config
+data.raw["string-setting"]["saws-scrap-recipe"].hidden = true
+data.raw["string-setting"]["saws-scrap-recipe"].allowed_values = {"space-age"}
+data.raw["string-setting"]["saws-scrap-recipe"].default_value = "space-age"
+data.raw["bool-setting"]["saws-lava"].hidden = true
+data.raw["bool-setting"]["saws-lava"].forced_value = true
+data.raw["bool-setting"]["saws-lava"].default_value = true
+data.raw["bool-setting"]["saws-bacteria-cultivation"].hidden = true
+data.raw["bool-setting"]["saws-bacteria-cultivation"].forced_value = true
+data.raw["bool-setting"]["saws-bacteria-cultivation"].default_value = true


### PR DESCRIPTION
These two settings breaks if set to true (which is the default value at least in the last SAWS version), this PR adds a new file in the generated mod that forces these two settings to `true` to prevent the mod from breaking.

I forced the scrap recipe setting because event if it doesn't break on startup I think the generation would assume you are able to get ice from scrap which is only available with the original scrap recipe.

I did a generation with the updated code and the mod did load perfectly in a brand new Factorio instance (to ensure it didn't inherit any mod settings)