### PR TITLE
Keymaster's Keep: Fix shop sanity destroying low trial count settings

### DIFF
--- a/worlds/keymasters_keep/world.py
+++ b/worlds/keymasters_keep/world.py
@@ -252,7 +252,7 @@ class KeymastersKeepWorld(World):
             locations_needed += self.artifacts_of_resolve_total
 
         if self.shops:
-            locations_needed += 50  # We add unique relics to the pool when shops are enabled
+            locations_needed += self.shop_items_maximum * shop_count  # We add unique relics to the pool when shops are enabled
 
         area_trials_range_modified: bool = False
 


### PR DESCRIPTION
## What is this fixing or adding?
This PR changes the hard coded 50 extra locations added for shop sanity to the theoretical maximum instead. This makes it so shop sanity is now compatible with a low trial count per keep, instead of adding a ton of trials out of nowhere.

## How was this tested?
I used a yaml with the following settings:
- goal: keymasters_challenge
- artifacts_of_resolve_total: 5
- artifacts_of_resolve_required: 3
- keep_areas: 10
- magic_keys_total: 15
- lock_magic_keys: 1 to 3
- area_trials: 1 to 3
- unlocked_areas: 1
- shops_: true
- shop_items: 3 (min and max)
- shop_items_progression_percentage_chance: 100

Before the fix, it would force me to have 7-8 trials per keep, which is way too high compared to the progression items in the pool. After the fix, I generated with the same yaml, and I got only 2-3 trials per keep, which makes more sense.

[Keymaster's Keep.yaml](https://github.com/user-attachments/files/23905617/Keymaster.s.Keep.yaml)
