### PR TITLE
Add game selection bag size options

### DIFF
--- a/worlds/keymasters_keep/game_objective_generator.py
+++ b/worlds/keymasters_keep/game_objective_generator.py
@@ -72,12 +72,14 @@ class GameObjectiveGenerator:
         self,
         plan: List[int] = None,
         random: Random = None,
+        bag_size: int = 1,
         include_difficult: bool = False,
         excluded_games_difficult: List[str] = None,
         include_time_consuming: bool = False,
         excluded_games_time_consuming: List[str] = None,
         game_medley_mode: bool = False,
         game_medley_percentage_chance: int = 100,
+        game_medley_bag_size: int = 1,
     ) -> GameObjectiveGeneratorData:
         if plan is None or not len(plan):
             return list()
@@ -89,9 +91,17 @@ class GameObjectiveGenerator:
 
         if plan_length <= len(self.games):
             game_selection = random.sample(self.games, plan_length)
-        else:
+        elif bag_size <= 0:
             for _ in range(plan_length):
                 game_selection.append(random.choice(self.games))
+        else:
+            game_bag: List[Type[Game]] = self.games * bag_size
+            while len(game_selection) < plan_length:
+                game_index: int = random.choice([i for i in range(len(game_bag))])
+                game_selection.append(game_bag[game_index])
+                game_bag.pop(game_index)
+                if len(game_bag) == 0:
+                    game_bag = list(self.games)
 
         if game_medley_mode:
             for i in range(len(game_selection)):
@@ -118,13 +128,16 @@ class GameObjectiveGenerator:
                 optional_constraints: List[str]
                 objectives: List[str]
 
-                optional_constraints, objectives, objectives_in_use = game.generate_objectives(
-                    count=count,
-                    include_difficult=include_difficult,
-                    include_time_consuming=include_time_consuming,
-                    excluded_games_time_consuming=excluded_games_time_consuming,
-                    excluded_games_difficult=excluded_games_difficult,
-                    objectives_in_use=objectives_in_use,
+                optional_constraints, objectives, objectives_in_use = (
+                    game.generate_objectives(
+                        count=count,
+                        bag_size=game_medley_bag_size,
+                        include_difficult=include_difficult,
+                        include_time_consuming=include_time_consuming,
+                        excluded_games_time_consuming=excluded_games_time_consuming,
+                        excluded_games_difficult=excluded_games_difficult,
+                        objectives_in_use=objectives_in_use,
+                    )
                 )
 
                 data.append((game, optional_constraints, objectives))

--- a/worlds/keymasters_keep/games/game_medley_game.py
+++ b/worlds/keymasters_keep/games/game_medley_game.py
@@ -54,6 +54,7 @@ class GameMedleyGame(Game):
     def generate_objectives(
         self,
         count: int = 1,
+        bag_size: int = 1,
         include_difficult: bool = False,
         include_time_consuming: bool = False,
         excluded_games_time_consuming: list[str] = None,
@@ -70,10 +71,22 @@ class GameMedleyGame(Game):
 
         passes_templates: int = 0
 
+        game_bag: list[type[Game]] | None = None
+        if bag_size > 0:
+            game_bag = self.game_selection * bag_size
+
         while len(objectives) < count:
             passes_templates += 1
 
-            game: type[Game] = self.random.choice(self.game_selection)
+            game: type[Game]
+            if game_bag is None:
+                game = self.random.choice(self.game_selection)
+            else:
+                game_index: int = self.random.choice([i for i in range(len(game_bag))])
+                game = game_bag[game_index]
+                game_bag.pop(game_index)
+                if len(game_bag) == 0:
+                    game_bag = list(self.game_selection)
 
             is_in_time_consuming_exclusions: bool = game.game_name_with_platforms() in excluded_games_time_consuming
             include_time_consuming = include_time_consuming and not is_in_time_consuming_exclusions

--- a/worlds/keymasters_keep/options.py
+++ b/worlds/keymasters_keep/options.py
@@ -521,7 +521,9 @@ option_groups: typing.List[OptionGroup] = [
             GameMedleyMode,
             GameMedleyPercentageChance,
             GameMedleyGameSelection,
+            GameMedleyGameSelectionBagSize,
             GameSelection,
+            GameMedleyGameSelectionBagSize,
         ],
     ),
     OptionGroup(

--- a/worlds/keymasters_keep/options.py
+++ b/worlds/keymasters_keep/options.py
@@ -313,6 +313,19 @@ class GameMedleyGameSelection(OptionList):
     default = list()
 
 
+class GameMedleyGameSelectionBagSize(Range):
+    """
+    Determines the size of the bag from which the weighted games in 'game_medley_game_selection' will be randomly selected. For more information, see 'game_selection_bag_size'.
+    """
+
+    display_name: str = "Game Medley Game Selection Bag Size"
+
+    range_start: int = 0
+    range_end: int = 5
+
+    default = 1
+
+
 class GameSelection(OptionList):
     """
     Defines the game pool to select from.
@@ -326,6 +339,23 @@ class GameSelection(OptionList):
     valid_keys = sorted(AutoGameRegister.games.keys())
 
     default = sorted(AutoGameRegister.games.keys())
+
+
+class GameSelectionBagSize(Range):
+    """
+    Determines the size of the bag from which the weighted games in 'game_selection' will be randomly selected.
+
+    0: No bag will be used and games may appear multiple times unbounded.
+    1: The bag will be filled with 1 of each game and will be drawn from randomly until it is empty, resulting in an even distribution of games. If the bag becomes empty, it will be refilled.
+    2+: The bag will initially be filled with the chosen number of each game, resulting in a slightly less even distribution of games where the maximum number of each game is the chosen number. Subsequent fills will revert to an even distribution. Similar logic applies for all other bag sizes.
+    """
+
+    display_name: str = "Game Selection Bag Size"
+
+    range_start: int = 0
+    range_end: int = 5
+
+    default = 1
 
 
 class IncludeAdultOnlyOrUnratedGames(Toggle):
@@ -435,7 +465,9 @@ class KeymastersKeepOptions(PerGameCommonOptions, GameArchipelagoOptions):
     game_medley_mode: GameMedleyMode
     game_medley_percentage_chance: GameMedleyPercentageChance
     game_medley_game_selection: GameMedleyGameSelection
+    game_medley_game_selection_bag_size: GameMedleyGameSelectionBagSize
     game_selection: GameSelection
+    game_selection_bag_size: GameSelectionBagSize
     include_adult_only_or_unrated_games: IncludeAdultOnlyOrUnratedGames
     include_modern_console_games: IncludeModernConsoleGames
     include_difficult_objectives: IncludeDifficultObjectives

--- a/worlds/keymasters_keep/world.py
+++ b/worlds/keymasters_keep/world.py
@@ -126,9 +126,11 @@ class KeymastersKeepWorld(World):
     excluded_games_time_consuming_objectives: List[str]
     filler_item_names: List[str] = item_groups()["Filler"]
     game_medley_game_selection: List[str]
+    game_medley_game_selection_bag_size: int
     game_medley_mode: bool
     game_medley_percentage_chance: int
     game_selection: List[str]
+    game_selection_bag_size: int
     goal: KeymastersKeepGoals
     goal_game: str
     goal_game_optional_constraints: List[str]
@@ -285,8 +287,12 @@ class KeymastersKeepWorld(World):
         self.game_medley_mode = bool(self.options.game_medley_mode)
         self.game_medley_percentage_chance = self.options.game_medley_percentage_chance.value
         self.game_medley_game_selection = list(self.options.game_medley_game_selection.value)
+        self.game_medley_game_selection_bag_size = (
+            self.options.game_medley_game_selection_bag_size.value
+        )
 
         self.game_selection = list(self.options.game_selection.value)
+        self.game_selection_bag_size = self.options.game_selection_bag_size.value
 
         self.include_adult_only_or_unrated_games = bool(self.options.include_adult_only_or_unrated_games)
         self.include_modern_console_games = bool(self.options.include_modern_console_games)
@@ -850,12 +856,14 @@ class KeymastersKeepWorld(World):
         game_objective_data: GameObjectiveGeneratorData = generator.generate_from_plan(
             plan,
             self.random,
+            self.game_selection_bag_size,
             self.include_difficult_objectives,
             self.excluded_games_difficult_objectives,
             self.include_time_consuming_objectives,
             self.excluded_games_time_consuming_objectives,
             self.game_medley_mode,
             self.game_medley_percentage_chance,
+            self.game_medley_game_selection_bag_size,
         )
 
         self.area_games = dict()


### PR DESCRIPTION
## What is this fixing or adding?

This pull request adds two new options to Keymaster's Keep: `game_selection_bag_size` and `game_medley_game_selection_bag_size`. Both control how many of each game (in `game_selection` and `game_medley_game_selection` respectively) is allowed to appear at once when randomising which games to include in the world. Game bags preserve the weightings given to games in the selection options. The default values for both have been set to 1 to prevent future complaints, though a value of 0 will restore the original behaviour.

Fixes the complaints mentioned on Discord [here](https://discord.com/channels/731205301247803413/1321323711676284939/1445224599360114769) and [here](https://discord.com/channels/731205301247803413/1321323711676284939/1445746007945248888).

## How was this tested?

The changes were made directly to the Keymaster's Keep `.apworld` and were run through a couple of generations and hostings. They have simply been moved over to this updated codebase. Additional testing is still recommended.