### PR TITLE
Fix conquest_medallions_required initialization

### DIFF
--- a/worlds/keymasters_keep/archipelago.json
+++ b/worlds/keymasters_keep/archipelago.json
@@ -4,8 +4,8 @@
     "game": "Keymaster's Keep",
     "idgb_id": null,
     "minimum_ap_version": "0.6.1",
-    "world_version": "2.1.1",
+    "world_version": "2.1.2",
     "changelog":[
-        "Fixed crash when a shop contains a deprioritized item."
+        "Fixed crash when a shop contains a deprioritized item. Added backwards compatibility for worlds created before area_domination added."
     ]
 }

--- a/worlds/keymasters_keep/client.py
+++ b/worlds/keymasters_keep/client.py
@@ -143,11 +143,11 @@ class KeymastersKeepContext(CommonClient.CommonContext):
 
             self.area_trials = {}
             self.area_completion_locations = {}
+            self.conquest_medallions_required = {}
 
             area: str
             trials: list[str]
             for area, trials in _args["slot_data"]["area_trials"].items():
-                trial: str
                 self.area_trials[KeymastersKeepRegions(area)] = [
                     self.id_to_location_data[self.location_name_to_id[trial]] for trial in trials
                 ]
@@ -160,7 +160,10 @@ class KeymastersKeepContext(CommonClient.CommonContext):
             self.area_trials_minimum = _args["slot_data"]["area_trials_minimum"]
             self.artifacts_of_resolve_required = _args["slot_data"]["artifacts_of_resolve_required"]
             self.artifacts_of_resolve_total = _args["slot_data"]["artifacts_of_resolve_total"]
-            self.conquest_medallions_required = _args["slot_data"]["conquest_medallions_required"]
+            
+            if "conquest_medallions_required" in _args["slot_data"]:
+                self.conquest_medallions_required = _args["slot_data"]["conquest_medallions_required"]
+            
             self.game_medley_mode = _args["slot_data"]["game_medley_mode"]
             self.game_medley_percentage_chance = _args["slot_data"]["game_medley_percentage_chance"]
             self.goal = KeymastersKeepGoals(_args["slot_data"]["goal"])


### PR DESCRIPTION
There is one more variable from the Conquest Medallions that is missing. This adds that and removes an unneeded variable declaration.