### PR TITLE
Add forced game selection option

### DIFF
--- a/worlds/keymasters_keep/game_objective_generator.py
+++ b/worlds/keymasters_keep/game_objective_generator.py
@@ -29,6 +29,7 @@ class GameObjectiveGenerator:
     def __init__(
         self,
         allowable_games: List[str] = None,
+        forced_games: List[str] = None,
         allowable_games_medley: List[str] = None,
         game_medley_mode: bool = False,
         include_adult_only_or_unrated_games: bool = False,
@@ -49,6 +50,14 @@ class GameObjectiveGenerator:
 
         if not len(self.games):
             raise GameObjectiveGeneratorException("No games are left after game / objective filtering")
+
+        self.forced_games = self._filter_games(
+            forced_games,
+            include_adult_only_or_unrated_games,
+            include_modern_console_games,
+            include_difficult_objectives,
+            include_time_consuming_objectives,
+        )
 
         if game_medley_mode:
             self.games_medley = self._filter_games(
@@ -89,24 +98,52 @@ class GameObjectiveGenerator:
 
         game_selection: List[Type[Game]] = list()
 
-        if plan_length <= len(self.games):
-            game_selection = random.sample(self.games, plan_length)
-        elif bag_size <= 0:
-            for _ in range(plan_length):
-                game_selection.append(random.choice(self.games))
+        if len(self.forced_games) > 0:
+            if len(self.forced_games) > plan_length:
+                raise ValueError(
+                    f"Force selected games amount {len(self.forced_games)} is greater than permitted areas amount {plan_length}"
+                )
+            for forced_game in self.forced_games:
+                found: bool = False
+                for possible_game in self.games:
+                    if forced_game == possible_game:
+                        game_selection.append(possible_game)
+                        found = True
+                        break
+                if not found:
+                    raise ValueError(
+                        f"Force selected game {forced_game!r} not found in game selection list"
+                    )
+
+        def maybe_game_medley(expected: Type[Game]) -> Type[Game]:
+            if (
+                game_medley_mode
+                and random.randint(1, 100) <= game_medley_percentage_chance
+            ):
+                return GameMedleyGame
+            return expected
+
+        if bag_size <= 0:
+            for i in range(plan_length):
+                game_selection.append(maybe_game_medley(random.choice(self.games)))
         else:
             game_bag: List[Type[Game]] = self.games * bag_size
+            expected_drawn: int = bag_size
             while len(game_selection) < plan_length:
-                game_index: int = random.choice([i for i in range(len(game_bag))])
-                game_selection.append(game_bag[game_index])
-                game_bag.pop(game_index)
+                draw_game: Type[Game] = maybe_game_medley(random.choice(game_bag))
+                if draw_game not in game_bag:  # Game medley is never in the bag
+                    game_selection.append(draw_game)
+                    continue
+                drawn: int = game_selection.count(draw_game)
+                if drawn < expected_drawn:  # Force select affects draw rate otherwise
+                    game_selection.append(draw_game)
+                game_bag.remove(draw_game)
                 if len(game_bag) == 0:
                     game_bag = list(self.games)
+                    expected_drawn += bag_size
 
-        if game_medley_mode:
-            for i in range(len(game_selection)):
-                if random.randint(1, 100) <= game_medley_percentage_chance:
-                    game_selection[i] = GameMedleyGame
+        if len(self.forced_games) > 0:
+            random.shuffle(game_selection)
 
         data: GameObjectiveGeneratorData = list()
         objectives_in_use: Set[str] = set()

--- a/worlds/keymasters_keep/options.py
+++ b/worlds/keymasters_keep/options.py
@@ -375,6 +375,19 @@ class GameSelectionBagSize(Range):
     default = 1
 
 
+class GameSelectionForceSelect(OptionList):
+    """
+    Forces certain games to become areas, selected and placed randomly from this list. This option does not affect shops or the Keymaster's challenge room. If more games than permitted areas are specified, this option will cause an error. 'game_selection_bag_size' will treat games added by this option as if they have been pre-drawn from their respective bags.
+
+    You are allowed to add the same game multiple times here. This will cause that many instances of the game to appear as areas.
+    """
+
+    display_name: str = "Game Selection Force Select"
+    valid_keys = sorted(AutoGameRegister.games.keys())
+
+    default = list()
+
+
 class IncludeAdultOnlyOrUnratedGames(Toggle):
     """
     Determines if adult only or unrated games should be considered for the game pool.
@@ -486,6 +499,7 @@ class KeymastersKeepOptions(PerGameCommonOptions, GameArchipelagoOptions):
     game_medley_game_selection_bag_size: GameMedleyGameSelectionBagSize
     game_selection: GameSelection
     game_selection_bag_size: GameSelectionBagSize
+    game_selection_force_select: GameSelectionForceSelect
     include_adult_only_or_unrated_games: IncludeAdultOnlyOrUnratedGames
     include_modern_console_games: IncludeModernConsoleGames
     include_difficult_objectives: IncludeDifficultObjectives
@@ -542,6 +556,8 @@ option_groups: list[OptionGroup] = [
             GameMedleyGameSelection,
             GameMedleyGameSelectionBagSize,
             GameSelection,
+            GameSelectionBagSize,
+            GameSelectionForceSelect,
         ],
     ),
 ]

--- a/worlds/keymasters_keep/world.py
+++ b/worlds/keymasters_keep/world.py
@@ -134,6 +134,7 @@ class KeymastersKeepWorld(World):
     game_medley_percentage_chance: int
     game_selection: List[str]
     game_selection_bag_size: int
+    game_selection_force_select: List[str]
     goal: KeymastersKeepGoals
     goal_game: str
     goal_game_optional_constraints: List[str]
@@ -300,6 +301,7 @@ class KeymastersKeepWorld(World):
 
         self.game_selection = list(self.options.game_selection.value)
         self.game_selection_bag_size = self.options.game_selection_bag_size.value
+        self.game_selection_force_select = list(self.options.game_selection_force_select)
 
         self.include_adult_only_or_unrated_games = bool(self.options.include_adult_only_or_unrated_games)
         self.include_modern_console_games = bool(self.options.include_modern_console_games)
@@ -869,6 +871,7 @@ class KeymastersKeepWorld(World):
 
         generator: GameObjectiveGenerator = GameObjectiveGenerator(
             game_selection,
+            self.game_selection_force_select,
             self.game_medley_game_selection,
             self.game_medley_mode,
             self.include_adult_only_or_unrated_games,


### PR DESCRIPTION
## What is this fixing or adding?

This pull request adds a new option to Keymaster's Keep: `game_selection_force_select`. Whatever game names are passed into it are certain to appear as an area in every generation. Like other game name options, games can be specified multiple times to appear in that many areas. The `game_selection_bag_size` option is compatible with this new one.

This change was made in order to guarantee that meta games (e.g. alternatives to the in-built shop, consumeables, etc.) and other highly desired games (e.g. game backlog) appear in runs.

## How was this tested?

The changes were made to the Keymaster's Keep 2.1.2 source code and were run through a couple of generations and hostings. Additional testing is still recommended, especially with game medleys enabled.

Testing could not be done on later versions of Keymaster's Keep, for a code error related to `from .games import AutoGameRegister` not being found prevented Archipelago 0.6.6 from finishing generation.