### PR TITLE
Add objective bag size to control objective repeats

### DIFF
--- a/worlds/keymasters_keep/game.py
+++ b/worlds/keymasters_keep/game.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import abc
 
 from random import Random
-from typing import Any, Dict, List, Optional, Set, Tuple, Type
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 from .enums import KeymastersKeepGamePlatforms
 
@@ -109,9 +109,10 @@ class Game(metaclass=AutoGameRegister):
         count: int = 1,
         include_difficult: bool = False,
         include_time_consuming: bool = False,
-        objectives_in_use: Set[str] = None,
-    ) -> Tuple[List[str], List[str], Set[str]]:
-        objectives_in_use = objectives_in_use or set()
+        objectives_in_use: Dict[str, int] = None,
+        objective_bag_size: int = 1,
+    ) -> Tuple[List[str], List[str], Dict[str, int]]:
+        objectives_in_use = objectives_in_use or dict()
 
         optional_constraints: List[str] = list()
         optional_constraint_templates: List[GameObjectiveTemplate] = self.optional_game_constraint_templates()
@@ -141,14 +142,15 @@ class Game(metaclass=AutoGameRegister):
                 passes += 1
                 objective: str = template.generate_game_objective(self.random)
 
-                if objective not in objectives_in_use:
+                if objective_bag_size == 0 or objectives_in_use.get(objective, 0) < objective_bag_size:
                     objectives.append(objective)
-                    objectives_in_use.add(objective)
+                    objectives_in_use[objective] = objectives_in_use.get(objective, 0) + 1
 
                     break
 
                 if passes_templates > 50:
                     objectives.append(objective)
+                    objectives_in_use[objective] = objectives_in_use.get(objective, 0) + 1
                     break
 
                 if passes > 10:

--- a/worlds/keymasters_keep/game_objective_generator.py
+++ b/worlds/keymasters_keep/game_objective_generator.py
@@ -1,6 +1,6 @@
 import logging
 from random import Random
-from typing import Any, List, Set, Type, Union
+from typing import Any, Dict, List, Type, Union
 
 from Options import OptionError
 
@@ -84,6 +84,7 @@ class GameObjectiveGenerator:
         game_medley_mode: bool = False,
         game_medley_percentage_chance: int = 100,
         game_medley_bag_size: int = 1,
+        objective_bag_size: int = 1,
     ) -> GameObjectiveGeneratorData:
         if plan is None or not len(plan):
             return list()
@@ -141,7 +142,7 @@ class GameObjectiveGenerator:
             random.shuffle(game_selection)
 
         data: GameObjectiveGeneratorData = list()
-        objectives_in_use: Set[str] = set()
+        objectives_in_use: Dict[str, int] = dict()
 
         i: int
         count: int
@@ -169,6 +170,7 @@ class GameObjectiveGenerator:
                         excluded_games_time_consuming=excluded_games_time_consuming,
                         excluded_games_difficult=excluded_games_difficult,
                         objectives_in_use=objectives_in_use,
+                        objective_bag_size=objective_bag_size,
                     )
                 )
 
@@ -208,6 +210,7 @@ class GameObjectiveGenerator:
                         include_difficult=include_difficult,
                         include_time_consuming=include_time_consuming,
                         objectives_in_use=objectives_in_use,
+                        objective_bag_size=objective_bag_size,
                     )
                 except Exception as e:
                     raise GameObjectiveGeneratorException(

--- a/worlds/keymasters_keep/games/game_medley_game.py
+++ b/worlds/keymasters_keep/games/game_medley_game.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from random import Random
-from typing import Any, List, Set, Tuple, Type
+from typing import Any, Dict, List, Tuple, Type
 
 from ..enums import KeymastersKeepGamePlatforms
 from ..game import Game
@@ -59,12 +59,13 @@ class GameMedleyGame(Game):
         include_time_consuming: bool = False,
         excluded_games_time_consuming: list[str] = None,
         excluded_games_difficult: list[str] = None,
-        objectives_in_use: set[str] = None,
-    ) -> Tuple[list[str], list[str], set[str]]:
+        objectives_in_use: Dict[str, int] = None,
+        objective_bag_size: int = 1,
+    ) -> Tuple[list[str], list[str], Dict[str, int]]:
         excluded_games_time_consuming = excluded_games_time_consuming or []
         excluded_games_difficult = excluded_games_difficult or []
 
-        objectives_in_use = objectives_in_use or set()
+        objectives_in_use = objectives_in_use or dict()
 
         optional_constraints: list[str] = []
         objectives: list[str] = []
@@ -129,18 +130,17 @@ class GameMedleyGame(Game):
                 passes += 1
 
                 objective: str = template.generate_game_objective(self.random)
+                prefixed_objective: str = f"{game.name} -> {objective}"
 
-                if objective not in objectives_in_use:
-                    objective = f"{game.name} -> {objective}"
-
-                    objectives.append(objective)
-                    objectives_in_use.add(objective)
+                if objective_bag_size == 0 or objectives_in_use.get(prefixed_objective, 0) < objective_bag_size:
+                    objectives.append(prefixed_objective)
+                    objectives_in_use[prefixed_objective] = objectives_in_use.get(prefixed_objective, 0) + 1
 
                     break
 
                 if passes_templates > 50:
-                    objective = f"{game.name} -> {objective}"
-                    objectives.append(objective)
+                    objectives.append(prefixed_objective)
+                    objectives_in_use[prefixed_objective] = objectives_in_use.get(prefixed_objective, 0) + 1
 
                     break
 

--- a/worlds/keymasters_keep/options.py
+++ b/worlds/keymasters_keep/options.py
@@ -389,6 +389,23 @@ class GameSelectionForceSelect(OptionList):
     default = []
 
 
+class ObjectiveSelectionBagSize(Range):
+    """
+    Determines how many times an identical objective can appear across the entire keep.
+
+    0: No uniquification — objectives may repeat freely across the keep.
+    1: Each objective can appear at most once globally (default behavior).
+    2+: Each objective can appear up to the chosen number of times before being excluded.
+    """
+
+    display_name: str = "Objective Selection Bag Size"
+
+    range_start: int = 0
+    range_end: int = 5
+
+    default = 1
+
+
 class IncludeAdultOnlyOrUnratedGames(Toggle):
     """
     Determines if adult only or unrated games should be considered for the game pool.
@@ -501,6 +518,7 @@ class KeymastersKeepOptions(PerGameCommonOptions, GameArchipelagoOptions):
     game_selection: GameSelection
     game_selection_bag_size: GameSelectionBagSize
     game_selection_force_select: GameSelectionForceSelect
+    objective_selection_bag_size: ObjectiveSelectionBagSize
     include_adult_only_or_unrated_games: IncludeAdultOnlyOrUnratedGames
     include_modern_console_games: IncludeModernConsoleGames
     include_difficult_objectives: IncludeDifficultObjectives
@@ -559,6 +577,7 @@ option_groups: list[OptionGroup] = [
             GameSelection,
             GameSelectionBagSize,
             GameSelectionForceSelect,
+            ObjectiveSelectionBagSize,
         ],
     ),
 ]

--- a/worlds/keymasters_keep/options.py
+++ b/worlds/keymasters_keep/options.py
@@ -394,8 +394,11 @@ class ObjectiveSelectionBagSize(Range):
     Determines how many times an identical objective can appear across the entire keep.
 
     0: No uniquification — objectives may repeat freely across the keep.
-    1: Each objective can appear at most once globally (default behavior).
-    2+: Each objective can appear up to the chosen number of times before being excluded.
+    1: Each objective should appear at most once globally (default behavior).
+    2+: Each objective should appear up to the chosen number of times before being excluded.
+
+    Note: This is best-effort. If the available objective pool for a game is too small to fill the requested number of
+    trials without exceeding the cap, duplicate objectives may still appear.
     """
 
     display_name: str = "Objective Selection Bag Size"

--- a/worlds/keymasters_keep/world.py
+++ b/worlds/keymasters_keep/world.py
@@ -145,6 +145,7 @@ class KeymastersKeepWorld(World):
     include_modern_console_games: bool
     include_time_consuming_objectives: bool
     keep_areas: int
+    objective_selection_bag_size: int
     keep_data: Any
     lock_combinations: Dict[KeymastersKeepRegions, Optional[List[KeymastersKeepItems]]]
     lock_magic_keys_maximum: int
@@ -302,6 +303,8 @@ class KeymastersKeepWorld(World):
         self.game_selection = list(self.options.game_selection.value)
         self.game_selection_bag_size = self.options.game_selection_bag_size.value
         self.game_selection_force_select = list(self.options.game_selection_force_select)
+
+        self.objective_selection_bag_size = self.options.objective_selection_bag_size.value
 
         self.include_adult_only_or_unrated_games = bool(self.options.include_adult_only_or_unrated_games)
         self.include_modern_console_games = bool(self.options.include_modern_console_games)
@@ -902,6 +905,7 @@ class KeymastersKeepWorld(World):
             self.game_medley_mode,
             self.game_medley_percentage_chance,
             self.game_medley_game_selection_bag_size,
+            self.objective_selection_bag_size,
         )
 
         self.area_games = dict()


### PR DESCRIPTION
Introduce an objective bag size to allow objectives to repeat a configurable number of times across the keep.