### PR TITLE
Swap min/max and warn on invalid ranges

### DIFF
--- a/worlds/keymasters_keep/options.py
+++ b/worlds/keymasters_keep/options.py
@@ -49,34 +49,36 @@ class ArtifactsOfResolveTotal(Range):
     default = 5
 
 
-class ArtifactsOfResolveRequired(Range):
+class ArtifactsOfResolvePercentageRequired(Range):
     """
-    Determines how many Artifacts of Resolve are required to unlock the Keymaster's challenge room.
+    Determines the percentage of Artifacts of Resolve required to unlock the Keymaster's challenge room.
+    The required count is calculated from the total, rounded up.
 
     Only relevant if the selected goal is Keymaster's Challenge.
     """
 
-    display_name: str = "Artifacts of Resolve Required"
+    display_name: str = "Artifacts of Resolve Percentage Required"
 
     range_start: int = 1
-    range_end: int = 25
+    range_end: int = 100
 
-    default = 3
+    default = 60
 
 
-class MagicKeysRequired(Range):
+class MagicKeysPercentageRequired(Range):
     """
-    Determines how many Magic Keys are required before escaping the Keymaster's Keep.
+    Determines the percentage of Magic Keys required before escaping the Keymaster's Keep.
+    The required count is calculated from the total, rounded up.
 
     Only relevant if the selected goal is Magic Key Heist.
     """
 
-    display_name: str = "Magic Keys Required"
+    display_name: str = "Magic Keys Percentage Required"
 
-    range_start: int = 10
-    range_end: int = 50
+    range_start: int = 1
+    range_end: int = 100
 
-    default = 18
+    default = 60
 
 
 class ConquestMedallionsPercentageRequired(Range):
@@ -146,6 +148,8 @@ class LockMagicKeysMinimum(Range):
 
     The amount of keys required to unlock an area will be a random number between this value and the maximum. Note that
     this option will be ignored for the first few areas to ensure the game is completable.
+
+    If this value is greater than the maximum, the values will be swapped.
     """
 
     display_name: str = "Lock Keys Minimum"
@@ -162,6 +166,8 @@ class LockMagicKeysMaximum(Range):
 
     The amount of keys required to unlock an area will be a random number between the minimum and this value. Note that
     this option will be ignored for the first few areas to ensure the game is completable.
+
+    If this value is less than the minimum, the values will be swapped.
     """
 
     display_name: str = "Lock Keys Maximum"
@@ -178,6 +184,8 @@ class AreaTrialsMinimum(Range):
 
     The amount of trials in an area will be a random number between this value and the maximum, but might get adjusted
     upwards to hold the item pool size.
+
+    If this value is greater than the maximum, the values will be swapped.
     """
 
     display_name: str = "Area Trials Minimum"
@@ -194,6 +202,8 @@ class AreaTrialsMaximum(Range):
 
     The amount of trials in an area will be a random number between the minimum and this value, but might get adjusted
     upwards to hold the item pool size.
+
+    If this value is less than the minimum, the values will be swapped.
     """
 
     display_name: str = "Area Trials Maximum"
@@ -236,6 +246,8 @@ class ShopItemsMinimum(Range):
     Determines the minimum amount of items that could be sold in a shop.
 
     The amount of items sold in a shop will be a random number between this value and the maximum.
+
+    If this value is greater than the maximum, the values will be swapped.
     """
 
     display_name: str = "Shop Items Minimum"
@@ -251,6 +263,8 @@ class ShopItemsMaximum(Range):
     Determines the maximum amount of items that could be sold in a shop.
 
     The amount of items sold in a shop will be a random number between the minimum and this value.
+
+    If this value is less than the minimum, the values will be swapped.
     """
 
     display_name: str = "Shop Items Maximum"
@@ -478,8 +492,8 @@ class KeymastersKeepOptions(PerGameCommonOptions, GameArchipelagoOptions):
     start_inventory_from_pool: StartInventoryPool
     goal: Goal
     artifacts_of_resolve_total: ArtifactsOfResolveTotal
-    artifacts_of_resolve_required: ArtifactsOfResolveRequired
-    magic_keys_required: MagicKeysRequired
+    artifacts_of_resolve_percentage_required: ArtifactsOfResolvePercentageRequired
+    magic_keys_percentage_required: MagicKeysPercentageRequired
     conquest_medallions_percentage_required: ConquestMedallionsPercentageRequired
     keep_areas: KeepAreas
     magic_keys_total: MagicKeysTotal
@@ -519,8 +533,8 @@ option_groups: list[OptionGroup] = [
         [
             Goal,
             ArtifactsOfResolveTotal,
-            ArtifactsOfResolveRequired,
-            MagicKeysRequired,
+            ArtifactsOfResolvePercentageRequired,
+            MagicKeysPercentageRequired,
             ConquestMedallionsPercentageRequired,
         ],
     ),

--- a/worlds/keymasters_keep/world.py
+++ b/worlds/keymasters_keep/world.py
@@ -205,23 +205,29 @@ class KeymastersKeepWorld(World):
         self.lock_magic_keys_maximum = self.options.lock_magic_keys_maximum.value
 
         if self.lock_magic_keys_minimum > self.lock_magic_keys_maximum:
-            self.lock_magic_keys_maximum = self.lock_magic_keys_minimum
+            self.lock_magic_keys_minimum, self.lock_magic_keys_maximum = self.lock_magic_keys_maximum, self.lock_magic_keys_minimum
 
-            logging.warning(
+            warning_message = (
                 f"Keymaster's Keep: {self.player_name} has a minimum lock magic keys value greater than the maximum. "
-                "Using minimum value for maximum."
+                "Swapping minimum and maximum values."
             )
+
+            print(warning_message)
+            logging.warning(warning_message)
 
         self.area_trials_minimum = self.options.area_trials_minimum.value
         self.area_trials_maximum = self.options.area_trials_maximum.value
 
         if self.area_trials_minimum > self.area_trials_maximum:
-            self.area_trials_maximum = self.area_trials_minimum
+            self.area_trials_minimum, self.area_trials_maximum = self.area_trials_maximum, self.area_trials_minimum
 
-            logging.warning(
+            warning_message = (
                 f"Keymaster's Keep: {self.player_name} has a minimum area trials value greater than the maximum. "
-                "Using minimum value for maximum."
+                "Swapping minimum and maximum values."
             )
+
+            print(warning_message)
+            logging.warning(warning_message)
 
         self.shops = bool(self.options.shops_)
         self.shops_percentage_chance = self.options.shops_percentage_chance.value
@@ -230,12 +236,15 @@ class KeymastersKeepWorld(World):
         self.shop_items_maximum = self.options.shop_items_maximum.value
 
         if self.shop_items_minimum > self.shop_items_maximum:
-            self.shop_items_maximum = self.shop_items_minimum
+            self.shop_items_minimum, self.shop_items_maximum = self.shop_items_maximum, self.shop_items_minimum
 
-            logging.warning(
+            warning_message = (
                 f"Keymaster's Keep: {self.player_name} has a minimum shop items value greater than the maximum. "
-                "Using minimum value for maximum."
+                "Swapping minimum and maximum values."
             )
+
+            print(warning_message)
+            logging.warning(warning_message)
 
         self.shop_items_progression_percentage_chance = self.options.shop_items_progression_percentage_chance.value
         self.shop_hints = bool(self.options.shop_hints)

--- a/worlds/keymasters_keep/world.py
+++ b/worlds/keymasters_keep/world.py
@@ -177,24 +177,24 @@ class KeymastersKeepWorld(World):
         self.artifacts_of_resolve_total = self.options.artifacts_of_resolve_total.value
 
         if self.artifacts_of_resolve_required > self.artifacts_of_resolve_total:
-            self.artifacts_of_resolve_total = self.artifacts_of_resolve_required
+            self.artifacts_of_resolve_required, self.artifacts_of_resolve_total = self.artifacts_of_resolve_total, self.artifacts_of_resolve_required
 
             if self.goal == KeymastersKeepGoals.KEYMASTERS_CHALLENGE:
                 logging.warning(
-                    f"Keymaster's Keep: {self.player_name} has more required artifacts than total artifacts. Using "
-                    "required amount for total."
+                    f"Keymaster's Keep: {self.player_name} has more required artifacts than total artifacts. "
+                    "Swapping required and total values."
                 )
 
         self.magic_keys_required = self.options.magic_keys_required.value
         self.magic_keys_total = self.options.magic_keys_total.value
 
         if self.magic_keys_required > self.magic_keys_total:
-            self.magic_keys_total = self.magic_keys_required
+            self.magic_keys_required, self.magic_keys_total = self.magic_keys_total, self.magic_keys_required
 
             if self.goal == KeymastersKeepGoals.MAGIC_KEY_HEIST:
                 logging.warning(
-                    f"Keymaster's Keep: {self.player_name} has more required magic keys than total magic keys. Using "
-                    "required amount for total."
+                    f"Keymaster's Keep: {self.player_name} has more required magic keys than total magic keys. "
+                    "Swapping required and total values."
                 )
 
         self.keep_areas = self.options.keep_areas.value
@@ -207,13 +207,10 @@ class KeymastersKeepWorld(World):
         if self.lock_magic_keys_minimum > self.lock_magic_keys_maximum:
             self.lock_magic_keys_minimum, self.lock_magic_keys_maximum = self.lock_magic_keys_maximum, self.lock_magic_keys_minimum
 
-            warning_message = (
+            logging.warning(
                 f"Keymaster's Keep: {self.player_name} has a minimum lock magic keys value greater than the maximum. "
                 "Swapping minimum and maximum values."
             )
-
-            print(warning_message)
-            logging.warning(warning_message)
 
         self.area_trials_minimum = self.options.area_trials_minimum.value
         self.area_trials_maximum = self.options.area_trials_maximum.value
@@ -221,13 +218,10 @@ class KeymastersKeepWorld(World):
         if self.area_trials_minimum > self.area_trials_maximum:
             self.area_trials_minimum, self.area_trials_maximum = self.area_trials_maximum, self.area_trials_minimum
 
-            warning_message = (
+            logging.warning(
                 f"Keymaster's Keep: {self.player_name} has a minimum area trials value greater than the maximum. "
                 "Swapping minimum and maximum values."
             )
-
-            print(warning_message)
-            logging.warning(warning_message)
 
         self.shops = bool(self.options.shops_)
         self.shops_percentage_chance = self.options.shops_percentage_chance.value
@@ -238,13 +232,10 @@ class KeymastersKeepWorld(World):
         if self.shop_items_minimum > self.shop_items_maximum:
             self.shop_items_minimum, self.shop_items_maximum = self.shop_items_maximum, self.shop_items_minimum
 
-            warning_message = (
+            logging.warning(
                 f"Keymaster's Keep: {self.player_name} has a minimum shop items value greater than the maximum. "
                 "Swapping minimum and maximum values."
             )
-
-            print(warning_message)
-            logging.warning(warning_message)
 
         self.shop_items_progression_percentage_chance = self.options.shop_items_progression_percentage_chance.value
         self.shop_hints = bool(self.options.shop_hints)

--- a/worlds/keymasters_keep/world.py
+++ b/worlds/keymasters_keep/world.py
@@ -173,29 +173,17 @@ class KeymastersKeepWorld(World):
         self.goal_game_optional_constraints = None
         self.goal_trial_game_objective = None
 
-        self.artifacts_of_resolve_required = self.options.artifacts_of_resolve_required.value
         self.artifacts_of_resolve_total = self.options.artifacts_of_resolve_total.value
 
-        if self.artifacts_of_resolve_required > self.artifacts_of_resolve_total:
-            self.artifacts_of_resolve_required, self.artifacts_of_resolve_total = self.artifacts_of_resolve_total, self.artifacts_of_resolve_required
+        self.artifacts_of_resolve_required = math.ceil(
+            self.artifacts_of_resolve_total * (self.options.artifacts_of_resolve_percentage_required.value / 100.0)
+        )
 
-            if self.goal == KeymastersKeepGoals.KEYMASTERS_CHALLENGE:
-                logging.warning(
-                    f"Keymaster's Keep: {self.player_name} has more required artifacts than total artifacts. "
-                    "Swapping required and total values."
-                )
-
-        self.magic_keys_required = self.options.magic_keys_required.value
         self.magic_keys_total = self.options.magic_keys_total.value
 
-        if self.magic_keys_required > self.magic_keys_total:
-            self.magic_keys_required, self.magic_keys_total = self.magic_keys_total, self.magic_keys_required
-
-            if self.goal == KeymastersKeepGoals.MAGIC_KEY_HEIST:
-                logging.warning(
-                    f"Keymaster's Keep: {self.player_name} has more required magic keys than total magic keys. "
-                    "Swapping required and total values."
-                )
+        self.magic_keys_required = math.ceil(
+            self.magic_keys_total * (self.options.magic_keys_percentage_required.value / 100.0)
+        )
 
         self.keep_areas = self.options.keep_areas.value
 


### PR DESCRIPTION
When a minimum option exceeded its corresponding maximum, the code previously forced the maximum to the minimum (losing the original maximum). This change swaps the min and max values instead, preserving the intended range order, and centralizes the warning text. It also prints the warning to stdout and logs it for lock_magic_keys, area_trials, and shop_items in KeymastersKeepWorld.