### PR TITLE
Fix recipe_ingredients option not being passed through to UT

### DIFF
--- a/worlds/factorio_saws/__init__.py
+++ b/worlds/factorio_saws/__init__.py
@@ -111,6 +111,7 @@ class FactorioSAWS(World):
             self.options.silo.value = self.get_ut_data("silo", self.options.silo.value)
             self.options.satellite.value = self.get_ut_data("satellite", self.options.satellite.value)
             self.options.goal.value = self.get_ut_data("goal", self.options.goal.value)
+            self.options.recipe_ingredients.value = self.get_ut_data("recipe_ingredients", self.options.recipe_ingredients.value)
 
         # if max < min, then swap max and min
         if self.options.max_tech_cost < self.options.min_tech_cost:
@@ -763,6 +764,7 @@ class FactorioSAWS(World):
             "silo": self.options.silo.value,
             "satellite": self.options.satellite.value,
             "goal": self.options.goal.value,
+            "recipe_ingredients": self.options.recipe_ingredients.value,
         }
 
     def interpret_slot_data(self, data):


### PR DESCRIPTION
## What is this fixing or adding?
missed recipe_ingredients option when writing UT support

## How was this tested?
not directly, but changing the `if self.options.recipe_ingredients:` to `if True or ...:` fixed my test seed that said I could craft green science when I actually couldn't; debug logs said it wasn't previously overriding the science pack recipes, but was once that `if` was passing.

## If this makes graphical changes, please attach screenshots.
n/a