### PR TITLE
SAWS: Improve CLI behaviour

### DIFF
--- a/worlds/factorio_saws/Client.py
+++ b/worlds/factorio_saws/Client.py
@@ -393,9 +393,12 @@ async def factorio_server_watcher(ctx: FactorioContext):
                     ctx.rcon_client = factorio_rcon.RCONClient("localhost", ctx.rcon_port, ctx.rcon_password,
                                                                timeout=5)
                     if not ctx.server:
-                        logger.info("Established bridge to Factorio Server. "
-                                    "Ready to connect to Archipelago via /connect")
-                        check_stdin()
+                        if ctx.server_address:
+                            await ctx.connect(ctx.server_address)
+                        else:
+                            logger.info("Established bridge to Factorio Server. "
+                                        "Ready to connect to Archipelago via /connect")
+                            check_stdin()
 
                 if not ctx.awaiting_bridge and "Archipelago Bridge Data available for game tick " in msg:
                     ctx.awaiting_bridge = True
@@ -538,7 +541,6 @@ async def factorio_spinup_server(ctx: FactorioContext) -> bool:
 
 async def main(make_context):
     ctx = make_context()
-    ctx.server_task = asyncio.create_task(server_loop(ctx), name="ServerLoop")
 
     if gui_enabled:
         ctx.run_gui()

--- a/worlds/factorio_saws/__init__.py
+++ b/worlds/factorio_saws/__init__.py
@@ -9,7 +9,7 @@ from Options import OptionError
 import Utils
 from BaseClasses import Region, Location, Item, Tutorial, ItemClassification
 from worlds.AutoWorld import World, WebWorld
-from worlds.LauncherComponents import Component, components, Type, launch_subprocess
+from worlds.LauncherComponents import Component, components, Type, launch as launch_component
 from worlds.generic import Rules
 from .settings import FactorioSAWSSettings
 from .Locations import location_pools, location_table, craftsanity_locations
@@ -23,9 +23,9 @@ from .Technologies import base_tech_table, recipe_sources, base_technology_table
     fluids, stacking_items, valid_ingredients, progressive_rows, ignored_recipes
 
 
-def launch_client():
+def launch_client(*args: str):
     from .Client import launch
-    launch_subprocess(launch, name="FactorioSAWSClient")
+    launch_component(launch, name="FactorioSAWSClient", args=args)
 
 
 components.append(Component("Factorio - Space Age Without Space Client", func=launch_client, component_type=Type.CLIENT))


### PR DESCRIPTION
## What is this fixing or adding?
- Restore CLI args by copying code from base Factorio apworld
- If --connect is provided, wait for the RCON bridge before trying to connect, to avoid the AP connection failing because we didn't get an RCON bridge yet

## How was this tested?
Started SAWS client in various ways, observed results:
- From launcher: same behaviour, client launches in new window
- From CLI, no args: same behaviour, client launches in new window
- From CLI, args: previously `TypeError: launch_client() takes 0 positional arguments but 5 were given`, now processes args as expected;
    - window is opened only if --nogui is not present.
    - --connect waits for the RCON bridge before connecting to AP.

## If this makes graphical changes, please attach screenshots.
n/a