### PR TITLE
SAWS: Make energylink bridge recipe actually random

### DIFF
--- a/worlds/factorio_saws/__init__.py
+++ b/worlds/factorio_saws/__init__.py
@@ -643,11 +643,13 @@ class FactorioSAWS(World):
                     ingredients_offset=ingredients_offset.value)
                 self.custom_recipes["satellite"] = new_recipe
         bridge = "ap-energy-bridge"
+        bridge_pool = sorted(science_pack_pools[self.options.max_science_pack.get_ordered_science_packs()[0]])
+        self.random.shuffle(bridge_pool)
         new_recipe = self.make_quick_recipe(
             Recipe(bridge, "crafting", {"replace_1": 1, "replace_2": 1, "replace_3": 1,
                                         "replace_4": 1, "replace_5": 1, "replace_6": 1},
                    {bridge: 1}, 10),
-            sorted(science_pack_pools[self.options.max_science_pack.get_ordered_science_packs()[0]]),
+            bridge_pool,
             ingredients_offset=ingredients_offset.value)
         for ingredient_name in new_recipe.ingredients:
             new_recipe.ingredients[ingredient_name] = self.random.randint(50, 500)


### PR DESCRIPTION
## What is this fixing or adding?
`make_quick_recipe` expects the pool to already be in a random order; the last N items of the pool will be selected. passing the list sorted means the SAWS bridge recipe is always tungsten ore, transport belt, stone brick, stone, scrap, pipe (adjusted for ingredient offset)

## How was this tested?
generated test seeds with code printing `new_recipe.ingredients` after L653
before the change, consistently `{'tungsten-ore': 1, 'transport-belt': 1, 'stone-brick': 1, 'stone': 1, 'scrap': 1}`
after the change, random e.g. `{'firearm-magazine': 1, 'copper-cable': 1, 'iron-ore': 1, 'stone': 1, 'copper-ore': 1}` or `{'firearm-magazine': 1, 'iron-gear-wheel': 1, 'pipe': 1, 'stone': 1, 'stone-brick': 1}`
(all with ingredients_offset -1)

## If this makes graphical changes, please attach screenshots.
n/a