### PR TITLE
SAWS: recipe tweaks

### DIFF
--- a/worlds/factorio_saws/Options.py
+++ b/worlds/factorio_saws/Options.py
@@ -278,6 +278,14 @@ class RecipeDifficultyFactor(Range):
     range_end = 250
 
 
+class RecipePoolMaxTiersBelow(Range):
+    """When randomizing ingredients, include the pools of science packs this many tiers below the target."""
+    display_name = "Randomized Recipe Pool Max Tiers Below"
+    range_start = 0
+    range_end = 10
+    default = 10
+
+
 class FactorioStartItems(OptionDict):
     """Mapping of Factorio internal item-name to amount granted on start."""
     display_name = "Starting Items"
@@ -549,6 +557,7 @@ class FactorioOptions(PerGameCommonOptions):
     recipe_ingredients: RecipeIngredients
     recipe_ingredients_offset: RecipeIngredientsOffset
     recipe_difficulty_factor: RecipeDifficultyFactor
+    recipe_pool_max_tiers_below: RecipePoolMaxTiersBelow
     imported_blueprints: ImportedBlueprint
     world_gen: FactorioWorldGen
     free_power: EnableLightning

--- a/worlds/factorio_saws/Options.py
+++ b/worlds/factorio_saws/Options.py
@@ -270,6 +270,14 @@ class RecipeIngredientsOffset(Range):
     range_end = 5
 
 
+class RecipeDifficultyFactor(Range):
+    """When randomizing ingredients, increase the estimated difficulty of each successive science pack ingredient pool by this percentage."""
+    display_name = "Randomized Recipe Difficulty Factor"
+    default = 200
+    range_start = 120
+    range_end = 250
+
+
 class FactorioStartItems(OptionDict):
     """Mapping of Factorio internal item-name to amount granted on start."""
     display_name = "Starting Items"
@@ -540,6 +548,7 @@ class FactorioOptions(PerGameCommonOptions):
     recipe_time: RecipeTime
     recipe_ingredients: RecipeIngredients
     recipe_ingredients_offset: RecipeIngredientsOffset
+    recipe_difficulty_factor: RecipeDifficultyFactor
     imported_blueprints: ImportedBlueprint
     world_gen: FactorioWorldGen
     free_power: EnableLightning

--- a/worlds/factorio_saws/Technologies.py
+++ b/worlds/factorio_saws/Technologies.py
@@ -554,6 +554,7 @@ fluids: Set[str] = set(fluids_future.result())
 del fluids_future
 
 
+@functools.cache
 def get_science_pack_pools(difficulty_factor: float) -> Dict[str, Set[str]]:
     def get_estimated_difficulty(recipe: Recipe):
 

--- a/worlds/factorio_saws/Technologies.py
+++ b/worlds/factorio_saws/Technologies.py
@@ -576,9 +576,12 @@ def get_science_pack_pools() -> Dict[str, Set[str]]:
         current = science_pack_pools[science_pack] = set()
         for name, recipe in recipes.items():
             if recipe.name not in ignored_recipes:
-                if (science_pack != "automation-science-pack" or not recipe.recursive_unlocking_technologies) \
-                        and get_estimated_difficulty(recipe) < current_difficulty:
-                    current |= set(recipe.products)
+                if (science_pack != "automation-science-pack" or not recipe.recursive_unlocking_technologies):
+                    difficulty = get_estimated_difficulty(recipe)
+                    for p in recipe.products:
+                        this_diff = difficulty * (10 if p in fluids else 1) / recipe.products[p]
+                        if this_diff < current_difficulty:
+                            current |= { p }
 
         if science_pack == "automation-science-pack":
             # Can't handcraft automation science if fluids end up in its recipe, making the seed impossible.

--- a/worlds/factorio_saws/Technologies.py
+++ b/worlds/factorio_saws/Technologies.py
@@ -554,8 +554,7 @@ fluids: Set[str] = set(fluids_future.result())
 del fluids_future
 
 
-@Utils.cache_argsless
-def get_science_pack_pools() -> Dict[str, Set[str]]:
+def get_science_pack_pools(difficulty_factor: float) -> Dict[str, Set[str]]:
     def get_estimated_difficulty(recipe: Recipe):
 
         base_ingredients = recipe.base_cost
@@ -593,7 +592,7 @@ def get_science_pack_pools() -> Dict[str, Set[str]]:
 
         current -= already_taken
         already_taken |= current
-        current_difficulty *= 2
+        current_difficulty *= difficulty_factor
 
     return science_pack_pools
 

--- a/worlds/factorio_saws/__init__.py
+++ b/worlds/factorio_saws/__init__.py
@@ -602,7 +602,16 @@ class FactorioSAWS(World):
 
         if self.options.recipe_ingredients:
             valid_pool = []
-            for pack in self.options.max_science_pack.get_ordered_science_packs():
+            for (idx, pack) in enumerate(self.options.max_science_pack.get_ordered_science_packs()):
+                if idx > self.options.recipe_pool_max_tiers_below:
+                    remove_pack_pool = self.options.max_science_pack.get_ordered_science_packs()[idx - self.options.recipe_pool_max_tiers_below - 1]
+                    for elem in science_pack_pools[remove_pack_pool]:
+                        try:
+                            valid_pool.remove(elem)
+                        except ValueError:
+                            # elem not in pool
+                            pass
+
                 valid_pool += sorted(science_pack_pools[pack])
                 self.random.shuffle(valid_pool)
                 if pack in recipes:  # skips over space science pack

--- a/worlds/factorio_saws/__init__.py
+++ b/worlds/factorio_saws/__init__.py
@@ -581,7 +581,7 @@ class FactorioSAWS(World):
     def set_custom_recipes(self):
         ingredients_offset = self.options.recipe_ingredients_offset
         original_rocket_part = recipes["rocket-part"]
-        science_pack_pools = get_science_pack_pools()
+        science_pack_pools = get_science_pack_pools(self.options.recipe_difficulty_factor.value / 100)
         valid_pool = sorted(science_pack_pools[self.options.max_science_pack.get_max_pack()]
                             & valid_ingredients)
         self.random.shuffle(valid_pool)


### PR DESCRIPTION
PR is semi-WIP; opening to get feedback on which parts of this make sense, which parts should be implemented differently, any other ideas along the same lines etc. Each top-level bullet point below is in its own atomic commit and can be pulled out independently if desired.

**Bold** items either need changes or thought before merge.

## What is this fixing or adding?
- Adjust ingredient difficulty calculation for result count
    - molten-iron is an expensive recipe (687), but gives a _lot_ of output - new difficulty 13.74
    - artificial-*-soil are also expensive (6085), but give 10 items per craft - new difficulty 608
    - Recipes that produce 1 output item (or fluid recipes that produce 10 fluid) are unchanged
- Add `recipe_difficulty_factor` option, controlling the difficulty increase from pool to pool (in percent)
    - Default 200, equivalent to the previous hardcoded `2`.
    - Values around 150 approximately match vanilla Factorio AP at space science.
    - I set the range to _roughly_ what actually succeeds generating; there are values within this range that will fail to generate usable pools for some science tiers, including some values between 150 and 200. **TODO: handle this better?**
- Add `recipe_pool_max_tiers_below` (**TODO: better name**) to control how many lower-tier science pools are included when selecting ingredients
    - Default 10 => all pools always included.
    - At 0, only the current tier's pool is included, the same way the rocket ingredients work.
    - **Should the default be reduced** so that the default settings can't roll a late-science as a trivial recipe? I don't think 0 is a sensible default, but perhaps 2-5 somewhere?

## How was this tested?
Generated test seeds with printed ingredient difficulty numbers, observed intended changes.
Generated various test seeds with various values for the new options, observed intended result.

## If this makes graphical changes, please attach screenshots.
n/a