### PR TITLE
SAWS: small fixes

### DIFF
--- a/worlds/factorio_saws/__init__.py
+++ b/worlds/factorio_saws/__init__.py
@@ -361,7 +361,7 @@ class FactorioSAWS(World):
                                                                                    victory_tech_names_p)
 
         if "Craft satellite" in self.multiworld.regions.location_cache[self.player]:
-            victory_tech_names_s = get_rocket_requirements(None, None, satellite_recipe, None)
+            victory_tech_names_s = get_rocket_requirements(None, None, self.get_recipe("satellite"), None)
             if self.options.silo == Silo.option_spawn:
                 victory_tech_names_s -= {"rocket-silo"}
             else:

--- a/worlds/factorio_saws/data/mod/reenable_lightning.lua
+++ b/worlds/factorio_saws/data/mod/reenable_lightning.lua
@@ -172,6 +172,10 @@ data.raw.planet.nauvis.lightning_properties = {
           string = "plant",
         },
         {
+          type = "prototype",
+          string = "fish",
+        },
+        {
           type = "countAsRockForFilteredDeconstruction",
           string = "true",
         },


### PR DESCRIPTION
## What is this fixing or adding?
- fix vanilla-recipe satellite craftsanity requirements
- exempt fish from lightning strikes

## How was this tested?
craftsanity: generated test seeds with `print(victory_tech_names_s)`, observed output changing from empty (before PR) to the expected set (with PR)
fish lightning: it wasn't; I checked the factorio files for the fish prototype: `type = "fish"`.

## If this makes graphical changes, please attach screenshots.
n/a