### PR TITLE
SAWS: Fix fluoroketone-hot byproduct experiencing cross-slot replication

### DIFF
--- a/worlds/factorio_saws/__init__.py
+++ b/worlds/factorio_saws/__init__.py
@@ -452,7 +452,7 @@ class FactorioSAWS(World):
                         new_ingredient = pool.pop(0)
                     liquids_used += 1 if new_ingredient in fluids else 0
                 new_ingredients[new_ingredient] = 10 if new_ingredient in fluids else 1
-        products = original.products
+        products = dict(original.products)
         category = self.get_category(original.category, liquids_used)
         if "fluoroketone-cold" in new_ingredients:
             products["fluoroketone-hot"] = max(1, round(new_ingredients["fluoroketone-cold"] / 2))
@@ -560,7 +560,7 @@ class FactorioSAWS(World):
             if remaining_num_ingredients > 1:
                 logging.warning("could not randomize recipe")
 
-        products = original.products
+        products = dict(original.products)
         category = self.get_category(original.category, liquids_used)
         if "fluoroketone-cold" in new_ingredients:
             products["fluoroketone-hot"] = max(1, round(new_ingredients["fluoroketone-cold"] / 2))


### PR DESCRIPTION
## What is this fixing or adding?
Fix mutation of globals causing the final SAWS slot's science byproducts to apply to all slots

## How was this tested?
Generated test 16xSAWS seeds with and without change:
- without, fluoroketone-cold ingredients were present without corresponding fluoroketone-hot byproduct
- with, all recipes had either ingredient and byproduct, or neither

## If this makes graphical changes, please attach screenshots.
n/a